### PR TITLE
Fix nested frames

### DIFF
--- a/src/Dom_walk.js
+++ b/src/Dom_walk.js
@@ -27,7 +27,7 @@ let DomWalk = null;
 	});
 
 	const element_tag = element[0].nodeName.toLowerCase();
-	if (element_tag == "iframe") {
+	if (element_tag == "iframe" || element_tag == "frame") {
 	    try {
 		// var sub_body = $('body', element.contents());
 		// each_displaying_helper(sub_body, pre_callback, post_callback);

--- a/src/activate.js
+++ b/src/activate.js
@@ -322,31 +322,36 @@ var Activate = null;
 	}, 250);
     }
 
+    // Finds a hint element on the page, or in a nested frame.
     function find_hint(hint, ...contents) {
-	var element;
-	var match = hint.match(/^\$\{(.*)\}("(.*)")?$/);
-	if (match) {
-	    element = $(match[1], ...contents);
-	    if (match[3]) {
-		target = match[3].toLowerCase();
-		element = element.filter(function(index, e) {
-		    return e.textContent.toLowerCase().includes(target);
-		});
-	    }
-	    element = element.first();
-	} else
-	    element = $("[CBV_hint_number='" + hint + "']", ...contents);
-	return element;
+        var element;
+        var match = hint.match(/^\$\{(.*)\}("(.*)")?$/);
+        if (match) {
+            element = $(match[1], ...contents);
+            if (match[3]) {
+                target = match[3].toLowerCase();
+                element = element.filter(function(index, e) {
+                    return e.textContent.toLowerCase().includes(target);
+                });
+            }
+            element = element.first();
+        } else {
+            element = $("[CBV_hint_number='" + hint + "']", ...contents);
+        }
+
+        // if the hint was not found, search recursively in any iframes
+        if (element.length == 0) {
+            var frames = $("iframe, frame", ...contents);
+            if (frames.length != 0) {
+                return find_hint(hint, frames.contents());
+            }
+        }
+
+        return element;
     }
 
     function goto_hint(hint, operation) {
 	var element = find_hint(hint);
-	if (element.length == 0) {
-	    frame = $("iframe");
-	    if (frame.length != 0) {
-		element = find_hint(hint, frame.contents());
-	    }
-	}
 	if (element.length == 0) {
 	    console.log("goto_hint: unable to find hint: " + hint);
 	    return;

--- a/src/activate.js
+++ b/src/activate.js
@@ -133,7 +133,7 @@ var Activate = null;
     }
 
     function href(element) {
-	if (element.is("iframe"))
+	if (element.is("iframe, frame"))
 	    return element[0].src;
 	if (element.attr("href"))
 	    return element[0].href;

--- a/src/add_hint.js
+++ b/src/add_hint.js
@@ -195,7 +195,7 @@ let AddHint = null;
 	if (element.is("select, option, textarea")) 
 	    return false;
 
-	if (element.is("iframe")) 
+	if (element.is("iframe, frame"))
 	    // iframe contents are displayed only if browser doesn't support iframe's
 	    return false;
 
@@ -424,7 +424,7 @@ let AddHint = null;
 
 
     function visual_contents(element) {
-	if (element.is("iframe"))
+	if (element.is("iframe, frame"))
 	    return [];
 	
 	const indent = css(element, "text-indent");

--- a/src/find_hint.js
+++ b/src/find_hint.js
@@ -34,6 +34,7 @@ let FindHint = null;
 	    case "textarea":
 	    case "keygen":
 	    case "iframe":
+	    case "frame":
 	    return true;
 
 	    case "input":

--- a/src/hints.js
+++ b/src/hints.js
@@ -40,14 +40,13 @@ var Hints = null;
 	    place_hints();
     }
 
-    function remove_hints() {
+    function remove_hints(from=document) {
 	AddHint.clear_work();
-	$("[CBV_hint_element]").remove();
-	$("[CBV_hint_number]").removeAttr("CBV_hint_number");
-	frame = $("iframe");
+	$("[CBV_hint_element]", from).remove();
+	$("[CBV_hint_number]", from).removeAttr("CBV_hint_number");
+	frame = $("iframe, frame", from);
 	if (frame.length != 0) {
-	    $("[CBV_hint_element]", frame.contents()).remove();
-	    $("[CBV_hint_number]", frame.contents()).removeAttr("CBV_hint_number");
+	    remove_hints(frame.contents());
 	}
 
 	next_CBV_hint_ = -1;


### PR DESCRIPTION
I frequently use a certain clunky and complicated website that uses multiple levels of nested `<iframe>` and `<frameset>`/`<frame>` elements. CBV currently doesn't work properly with more than one level of nested `<iframe>`, and doesn't consider `<frame>`s at all.

This pull request fixes this so that CBV adds, operates on, and removes hints as expected with any number of nested `<iframe>`/`<frame>` elements.

Here is an example test case that contains two `<frame>`s within an `<iframe>` within the top-level document: https://www.w3schools.com/jsref/tryit.asp?filename=tryjsref_frameset_rows